### PR TITLE
Removing style attr in addition to fill and stroke

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ function parse (file) {
         $(kid)
           .removeAttr('fill')
           .removeAttr('stroke')
+          .removeAttr('style')
       })
     $('svg').append(symbolNode)
   }


### PR DESCRIPTION
@kristoferjoseph  I have a need to remove the style attribute from the symbol nodes, in addition to the fill and stroke attributes which are already being removed. In my process for exporting SVG's, all styles are inlined into a style tag, which is good to have in the base file, but would be great if that was removed via this script.